### PR TITLE
Bug Fix - Group list user count

### DIFF
--- a/mobile/src/main/java/com/workout/sallyapp/model/entities/db/GroupEntity.java
+++ b/mobile/src/main/java/com/workout/sallyapp/model/entities/db/GroupEntity.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * Created by Yoav on 27-Apr-17.
  */
-@Table(database = SallyDatabase.class, name = GroupEntity.TABLE_NAME, cachingEnabled = true)
+@Table(database = SallyDatabase.class, name = GroupEntity.TABLE_NAME)
 @ManyToMany(referencedTable = UserEntity.class)
 public class GroupEntity extends BaseModel implements Parcelable {
     public static final String TABLE_NAME = "Group";

--- a/mobile/src/main/java/com/workout/sallyapp/model/repository/entity_repositories/GroupUserRepository.java
+++ b/mobile/src/main/java/com/workout/sallyapp/model/repository/entity_repositories/GroupUserRepository.java
@@ -26,6 +26,13 @@ public class GroupUserRepository {
                 .execute();
     }
 
+    public void deleteGroupUser(long groupId, long userId) {
+        SQLite.delete(GroupEntity_UserEntity.class)
+                .where(GroupEntity_UserEntity_Table.groupEntity_id.is(groupId))
+                .and(GroupEntity_UserEntity_Table.userEntity_serverId.is(userId))
+                .execute();
+    }
+
     public boolean isUserMemberSync(long groupId, long userId) {
         return SQLite.selectCountOf()
                 .from(GroupEntity_UserEntity.class)

--- a/mobile/src/main/java/com/workout/sallyapp/view/activities/MainActivity.java
+++ b/mobile/src/main/java/com/workout/sallyapp/view/activities/MainActivity.java
@@ -299,6 +299,7 @@ public class MainActivity extends BaseSallyActivity implements TabLayout.OnTabSe
     protected void onResume() {
         super.onResume();
         getScores();
+        getGroups();
     }
 
     private void setupViewPager(ViewPager viewPager) {
@@ -320,9 +321,6 @@ public class MainActivity extends BaseSallyActivity implements TabLayout.OnTabSe
             groupFragment = GroupFragment.newInstance();
             adapter.addFragment(groupFragment, getResources().getString(R.string.group_tab_name));
             mGroupTabId = 2;
-
-            // Make network request
-            getGroups();
         }
         // Anonymous user
         else {

--- a/mobile/src/main/java/com/workout/sallyapp/view/fragments/MainFragment.java
+++ b/mobile/src/main/java/com/workout/sallyapp/view/fragments/MainFragment.java
@@ -21,7 +21,7 @@ import com.workout.sallyapp.view.ui.InitialsGenerator;
 
 public class MainFragment extends Fragment implements LoaderManager.LoaderCallbacks<Integer> {
 
-    public static final int HISHSCORE_CURSOR_LIST_LOADER_ID = 1;
+    public static final int HIGHSCORE_CURSOR_LIST_LOADER_ID = 1;
     public static String ARG_USER_NAME = "main_fragment_user_name";
     public static String ARG_USER_PHOTO_URL = "arg_user_photo_url";
 
@@ -107,7 +107,7 @@ public class MainFragment extends Fragment implements LoaderManager.LoaderCallba
         }
 
         // db
-        getLoaderManager().initLoader(HISHSCORE_CURSOR_LIST_LOADER_ID, null, this);
+        getLoaderManager().initLoader(HIGHSCORE_CURSOR_LIST_LOADER_ID, null, this);
     }
 
     @Override

--- a/mobile/src/main/java/com/workout/sallyapp/view/loaders/GroupsLoader.java
+++ b/mobile/src/main/java/com/workout/sallyapp/view/loaders/GroupsLoader.java
@@ -30,7 +30,6 @@ public class GroupsLoader extends BaseDbflowCursorListLoader<GroupEntity> {
                 .where(GroupEntity_UserEntity_Table.userEntity_serverId.is(mUserID))
                 .cursorList();
 
-
         return mData;
     }
 }

--- a/mobile/src/main/java/com/workout/sallyapp/view/services/MainActivityIntentService.java
+++ b/mobile/src/main/java/com/workout/sallyapp/view/services/MainActivityIntentService.java
@@ -104,6 +104,7 @@ public class MainActivityIntentService extends IntentService {
             @Override
             public void onResponse(Call<List<GroupEntity>> call, Response<List<GroupEntity>> response) {
                 if (response.isSuccessful()) {
+                    // TODO: This performs many DB tasks, some can be optimized (e.g. no need to save the same user over and over again)
                     mGroupRepository.saveGroups(response.body(), null);
                 } else {
                     APIError error = mErrorUtils.parseError(response);


### PR DESCRIPTION
Fixes #1 - GroupEntity was automatically cached, resulting in the group list not being updated when saving new group users to the local db.

Partially handles #2 - Query Groups on onResume

Fixes #3 - If another user leaves the group, their group-user record will now be deleted from the local db.

